### PR TITLE
modificar migraciones y modelos para tablas consumidor y vendedor

### DIFF
--- a/app/Models/Consumidor.php
+++ b/app/Models/Consumidor.php
@@ -12,82 +12,75 @@ class Consumidor extends Authenticatable
 
     protected $table = 'consumidor';
 
-    // Indicamos que el campo de autenticación es 'correo_consumidor'
     public function getAuthIdentifierName()
     {
-        return 'correo_consumidor';
+        return 'correo';
     }
 
     protected $fillable = [
         'nombre_consumidor',
-        'correo_consumidor',
+        'correo',
         'telefono_consumidor',
-        'clave',
-        'fotoPerfil_consumidor', // ¡Corregido! Estaba mal escrito antes
+        'password',
+        'fotoPerfil_consumidor',
         'rol_id',
     ];
 
     protected $hidden = [
-        'clave',
+        'password',
     ];
 
-    // Relación con Rol
+    //==========================================
+    //Relaciones
+    //==========================================
     public function rol()
     {
         return $this->belongsTo(Rol::class, 'rol_id');
     }
 
-    // ===============================
-    // Funciones básicas CRUD
-    // ===============================
-
-    // Crear usuario
+    //=====================================
+    //Funciones basicas de CRUD
+    //=====================================
     public static function crearUsuario(array $datos)
     {
-        $datos['clave'] = Hash::make($datos['clave']); // encriptar contraseña
+        $datos['password'] = Hash::make($datos['password']);
         return self::create($datos);
     }
 
-    // Actualizar usuario
     public function actualizarUsuario(array $datos)
     {
-        if (isset($datos['clave'])) {
-            $datos['clave'] = Hash::make($datos['clave']);
+        if (isset($datos['password'])) {
+            $datos['password'] = Hash::make($datos['password']);
         }
         return $this->update($datos);
     }
 
-    // Eliminar usuario
     public function eliminarUsuario()
     {
         return $this->delete();
     }
 
-    // Obtener todos los usuarios
     public static function listarUsuarios()
     {
         return self::all();
     }
 
-    // Obtener consumidor por ID
     public static function obtenerPorId($id)
     {
         return self::find($id);
     }
 
-    // ===============================
-    // Funciones para login
-    // ===============================
 
-    // Buscar usuario por correo
+    //==================================
+    //Funciones de verificacion
+    //==================================
     public static function buscarPorCorreo(string $correo)
     {
-        return self::where('correo_consumidor', $correo)->first();
+        return self::where('correo', $correo)->first();
     }
 
-    // Verificar contraseña
     public function verificarPassword(string $password)
     {
-        return Hash::check($password, $this->clave);
+        return Hash::check($password, $this->password);
     }
 }

--- a/app/Models/Vendedor.php
+++ b/app/Models/Vendedor.php
@@ -14,80 +14,73 @@ class Vendedor extends Authenticatable
 
     public function getAuthIdentifierName()
     {
-        return 'correo_vendedor';
+        return 'correo';
     }
 
     protected $fillable = [
         'nombre_vendedor',
         'dui',
-        'correo_vendedor',
+        'correo',
         'telefono_vendedor',
-        'clave',
+        'password',
         'fotoPerfil_vendedor',
         'rol_id',
     ];
 
     protected $hidden = [
-        'clave',
+        'password',
     ];
 
-    // Relación con Rol
+    //============================================
+    //Relaciones
+    //============================================
     public function rol()
     {
         return $this->belongsTo(Rol::class, 'rol_id');
     }
 
-    // ===============================
-    // Funciones básicas CRUD
-    // ===============================
-
-    // Crear vendedor
+    //=========================================
+    //Funciones basicas del crud
+    //=========================================
     public static function crearVendedor(array $datos)
     {
-        $datos['clave'] = Hash::make($datos['clave']);
+        $datos['password'] = Hash::make($datos['password']);
         return self::create($datos);
     }
 
-    // Actualizar vendedor
     public function actualizarVendedor(array $datos)
     {
-        if (isset($datos['clave'])) {
-            $datos['clave'] = Hash::make($datos['clave']);
+        if (isset($datos['password'])) {
+            $datos['password'] = Hash::make($datos['password']);
         }
         return $this->update($datos);
     }
 
-    // Eliminar vendedor
     public function eliminarVendedor()
     {
         return $this->delete();
     }
 
-    // Obtener todos los vendedores
     public static function listarVendedores()
     {
         return self::all();
     }
 
-    // Obtener vendedor por ID
     public static function obtenerPorId($id)
     {
         return self::find($id);
     }
 
-    // ===============================
-    // Funciones para login
-    // ===============================
-
-    // Buscar vendedor por correo
+    //========================================
+    //Funciones de verificacion
+    //========================================
     public static function buscarPorCorreo(string $correo)
     {
-        return self::where('correo_vendedor', $correo)->first();
+        return self::where('correo', $correo)->first();
     }
 
-    // Verificar contraseña
     public function verificarPassword(string $password)
     {
-        return Hash::check($password, $this->clave);
+        return Hash::check($password, $this->password);
     }
 }

--- a/database/migrations/2025_08_31_173436_create_consumidor_table.php
+++ b/database/migrations/2025_08_31_173436_create_consumidor_table.php
@@ -14,9 +14,9 @@ return new class extends Migration
         Schema::create('consumidor', function (Blueprint $table) {
             $table->id();
             $table->string('nombre_consumidor');
-            $table->string('correo_consumidor')->unique();
+            $table->string('correo')->unique();
             $table->string('telefono_consumidor')->nullable();
-            $table->string('clave');
+            $table->string('password');
             $table->unsignedBigInteger('rol_id');
             $table->string('fotoPerfil_consumidor')->nullable();
             $table->timestamps();

--- a/database/migrations/2025_09_08_221821_create_vendedor_table.php
+++ b/database/migrations/2025_09_08_221821_create_vendedor_table.php
@@ -15,9 +15,9 @@ return new class extends Migration
             $table->id();
             $table->string('nombre_vendedor');
             $table->string('dui')->unique();
-            $table->string('correo_vendedor')->unique();
+            $table->string('correo')->unique();
             $table->string('telefono_vendedor');
-            $table->string('clave');
+            $table->string('password');
             $table->unsignedBigInteger('rol_id');
             $table->string('fotoPerfil_vendedor')->nullable();
             $table->timestamps();


### PR DESCRIPTION
- se cambiaron los nombres de los campos de "correo_consumidor" y "correo_vendedor" a "correo" y, se cambió el nombre del campo "clave" a "password" para las migraciones y modelos de vendedor y consumidor.